### PR TITLE
Don't use React Refresh when dev server is not enabled

### DIFF
--- a/webpack/development.ts
+++ b/webpack/development.ts
@@ -29,7 +29,7 @@ const config = (dirPath: string): Configuration => {
       publicPath: "/",
     },
     plugins: [
-      new ReactRefreshWebpackPlugin(),
+      process.env.WEBPACK_DEV_SERVER && new ReactRefreshWebpackPlugin(),
       new DefinePlugin({
         __MAP_ACCESS_TOKEN__: JSON.stringify(development.mapAccessToken),
       }),
@@ -48,7 +48,7 @@ const config = (dirPath: string): Configuration => {
         scripts: ["libs.js"],
         publicPath: "/",
       }),
-    ],
+    ].filter(Boolean),
   };
 };
 


### PR DESCRIPTION
When running `npm run compile:development:source` this error is produced:
```
Error: [React Refresh] Hot Module Replacement (HMR) is not enabled! React Refresh requires HMR to function properly.
```

HMR is only enabled with `npm start` so this PR removes React Refresh from being required when running the command above.